### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "assemble-less": "~0.7.0",
-        "grunt": "~0.4.4",
+        "grunt": "~1.0.0",
         "grunt-autoprefixer": "~0.5.0",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
start-to-grunt is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `grunt`

This PR fixes the ReDoS vulnerability by upgrading `grunt` to version 1.0.0.

Check out the [Snyk test report](https://snyk.io/test/github/kn9ts/start-to-grunt) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
